### PR TITLE
Changements mineurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ sudo systemctl enable --now  bluetooth.service
 ### [PipeWire](https://pipewire.org/)
 Pour avoir du son **/!\ Dire oui à tout pour bien tout écraser avec les nouveaux paquets. /!\\**
 ```bash
-sudo pacman -S --needed pipewire pipewire-pulse pipewire-alsa pipewire-jack wireplumber
+sudo pacman -S --needed pipewire lib32-pipewire pipewire-pulse pipewire-alsa pipewire-jack wireplumber
 ```
 
 ## SOFTWARE CORE

--- a/post-installation
+++ b/post-installation
@@ -59,7 +59,7 @@ source $HOME/.bashrc
 # Installation de pipewire (son)
 print_step "Installation de pipewire"
 sudo pacman -Rdd --noconfirm pulseaudio jack2 pipewire-media-session
-sudo pacman -S --needed --noconfirm pipewire pipewire-pulse pipewire-alsa pipewire-jack wireplumber
+sudo pacman -S --needed --noconfirm pipewire lib32-pipewire pipewire-pulse pipewire-alsa pipewire-jack wireplumber
 
 # Détecter Nvidia ou AMD
 read -p "Quel carte graphique avez-vous ? (1: nvidia, 2: amd, 3: les deux, 4: aucun): " gpu

--- a/post-installation
+++ b/post-installation
@@ -129,7 +129,7 @@ fi
 
 # Installation des packets indispensables
 print_step "Installation des packets indispensables"
-yay -S --needed --noconfirm mkinitcpio-firmware xdg-desktop-portal neofetch power-profiles-daemon lib32-pipewire hunspell-fr p7zip unrar ttf-liberation noto-fonts noto-fonts-emoji ntfs-3g fuse2 bash-completion xdg-desktop-portal-kde xdg-desktop-portal-gtk okular print-manager gwenview spectacle partitionmanager ffmpegthumbs qt6-wayland kdeplasma-addons vlc
+yay -S --needed --noconfirm reflector-simple mkinitcpio-firmware xdg-desktop-portal neofetch power-profiles-daemon lib32-pipewire hunspell-fr p7zip unrar ttf-liberation noto-fonts noto-fonts-emoji ntfs-3g fuse2 bash-completion xdg-desktop-portal-kde xdg-desktop-portal-gtk okular print-manager gwenview spectacle partitionmanager ffmpegthumbs qt6-wayland kdeplasma-addons vlc
 
 # Installation des drivers manettes
 print_step "Installation des drivers manettes (Xbox, etc...)"

--- a/post-installation
+++ b/post-installation
@@ -129,7 +129,7 @@ fi
 
 # Installation des packets indispensables
 print_step "Installation des packets indispensables"
-yay -S --needed --noconfirm reflector-simple mkinitcpio-firmware xdg-desktop-portal neofetch power-profiles-daemon lib32-pipewire hunspell-fr p7zip unrar ttf-liberation noto-fonts noto-fonts-emoji ntfs-3g fuse2 bash-completion xdg-desktop-portal-kde xdg-desktop-portal-gtk okular print-manager gwenview spectacle partitionmanager ffmpegthumbs qt6-wayland kdeplasma-addons vlc
+yay -S --needed --noconfirm reflector-simple mkinitcpio-firmware xdg-desktop-portal neofetch power-profiles-daemon hunspell-fr p7zip unrar ttf-liberation noto-fonts noto-fonts-emoji ntfs-3g fuse2 bash-completion xdg-desktop-portal-kde xdg-desktop-portal-gtk okular print-manager gwenview spectacle partitionmanager ffmpegthumbs qt6-wayland kdeplasma-addons vlc
 
 # Installation des drivers manettes
 print_step "Installation des drivers manettes (Xbox, etc...)"


### PR DESCRIPTION
j'ai ajouter lib32-pipewire a la section pipewire (mauvaise section)

- le choix pour le firewall UFW

- rebuild-detector ajouté (repos extra de arch, inclus dans la doc de AUR)
- powerdevil de KDE ajouté (pour être utiliser avec power-profile-daemon)

- la ligne pour vulkan-refixes est commentée en attente de test

changement dans la commande pour le script : 

./post-installation ne fonctionne pas sans chmod +x
remplacé par
bash post-installation (ne nécessite pas chmod)