### PR TITLE
Add duplication workaround to safe_append_to_file 

### DIFF
--- a/post-installation-KDE
+++ b/post-installation-KDE
@@ -66,6 +66,7 @@ safe_append_to_file() {
             echo "Fichier original.ori détecté. Il sera utilisé comme source."
             sudo rm ${file}
             sudo cp ${file}.ori ${file}
+            safe_run echo "${text}" | sudo tee -a "${file}" > /dev/null
         else
         echo "Sauvegarde du fichier d'origine en .ori"
         sudo cp ${file} ${file}.ori

--- a/post-installation-KDE
+++ b/post-installation-KDE
@@ -63,10 +63,7 @@ safe_append_to_file() {
     if [[ -f ${file} ]] ; then
         echo "Le fichier ${file} a été détecté"
         if [[ -f ${file}.ori ]] ; then
-            echo "Fichier original.ori détecté. Il sera utilisé comme source."
-            sudo rm ${file}
-            sudo cp ${file}.ori ${file}
-            safe_run echo "${text}" | sudo tee -a "${file}" > /dev/null
+            echo "Fichier ${file}.ori a été détecté. rien a faire."
         else
         echo "Sauvegarde du fichier d'origine en .ori"
         sudo cp ${file} ${file}.ori

--- a/post-installation-KDE
+++ b/post-installation-KDE
@@ -51,10 +51,29 @@ print_step() {
     sleep 1
 }
 
+#safe_append_to_file() {
+#    local text="$1"
+#    local file="$2"
+#    safe_run echo "${text}" | sudo tee -a "${file}" > /dev/null
+#}
+
 safe_append_to_file() {
     local text="$1"
     local file="$2"
+    if [[ -f ${file} ]] ; then
+        echo "Le fichier ${file} a été détecté"
+        if [[ -f ${file}.ori ]] ; then
+            echo "Fichier original.ori détecté. Il sera utilisé comme source."
+            sudo rm ${file}
+            sudo cp ${file}.ori ${file}
+        else
+        echo "Sauvegarde du fichier d'origine en .ori"
+        sudo cp ${file} ${file}.ori
+        safe_run echo "${text}" | sudo tee -a "${file}" > /dev/null
+        fi
+    else
     safe_run echo "${text}" | sudo tee -a "${file}" > /dev/null
+    fi
 }
 
 update_system() {


### PR DESCRIPTION
Ajout de vérification à la fonction.
Lors du premier run, si le fichier existe, une copie de celui-ci est faite en .ori
Si l'on run encore le script la source devient le .ori et on applique le append.