### PR TITLE
Mise à jour de la partie 'timeshift'

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,10 +401,9 @@ yay -S timeshift
 
     *“BTRFS snapshots are supported only on BTRFS systems having an Ubuntu-type subvolume layout ”*
 
-- Pour bénéficier des sauvegardes automatiques, vous aurez besoin de cronie. (facultatif) 
+- Pour bénéficier des sauvegardes automatiques, vous aurez besoin de démarrer cronie. (facultatif) 
 
   ```
-  yay -S cronie
   sudo systemctl enable --now cronie
   ```
   


### PR DESCRIPTION
Le package cronie est désormais [une dépendance directe de timeshift](https://gitlab.archlinux.org/archlinux/packaging/packages/timeshift/-/blob/main/PKGBUILD?ref_type=heads#L16), il n'est donc plus nécessaire de l'installer manuellement après coup.
Bien que cela ne pose pas de problème en soit, ne pas l'installer explicitement permettra à pacman de bien le considérer comme une dépendance de timeshift et pas comme un paquet explicitement installé. En effet, un paquet marqué comme "explicitement installé" ne sera pas retiré par l'option `-R/--recursive` de pacman et ne sera jamais considéré comme un paquet orphelin si timeshift venait à se séparer de cronie en tant que de dépendance (voir `--asdeps` et `--asexplicit` dans la page de man `pacman`).

Egalement, le package timeshift n'est plus un paquet AUR. Il a été [migré sur le repo [extra]](https://archlinux.org/packages/extra/x86_64/timeshift/) il y a quelques mois (et j'en suis accessoirement le mainteneur :slightly_smiling_face:).
Il n'est donc plus nécessaire de l'installer via `yay`, il peut être installé directement via `pacman` (mais ce n'est évidemment pas obligé, je te laisse voir ce que tu préfères).

Je reste dispo au besoin!